### PR TITLE
Assign codeowners to fdms-dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/fdms-dev


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns fdms-dev as codeowners.