### PR TITLE
Assign codeowners to FDMS-dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/FDMS-dev


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns FDMS-dev as codeowners.

    Note: This is a shared library and the team assignment was done randomly as part of an initial organization effort. 
    If you believe this assignment should be adjusted, please reach out to the appropriate stakeholders.